### PR TITLE
Fix typo Py_GIL_DISALED -> Py_GIL_DISABLED

### DIFF
--- a/pymetabind.h
+++ b/pymetabind.h
@@ -195,7 +195,7 @@ struct pymb_registry {
 #endif
 };
 
-#if defined(Py_GIL_DISALED)
+#if defined(Py_GIL_DISABLED)
 inline void pymb_lock_registry(struct pymb_registry* registry) {
     PyMutex_Lock(&registry->mutex);
 }


### PR DESCRIPTION
Noticed a small typo while reading through the code - figured I'd send a quick fix. Nice work on this!