### PR TITLE
Fix leak and other small improvements

### DIFF
--- a/pymetabind.h
+++ b/pymetabind.h
@@ -635,7 +635,8 @@ PYMB_FUNC void pymb_add_framework(struct pymb_registry* registry,
     PYMB_LIST_FOREACH(struct pymb_framework*, other, registry->frameworks) {
         // Intern `abi_extra` strings so they can be compared by pointer
         if (other->abi_extra && framework->abi_extra &&
-            0 == strcmp(other->abi_extra, framework->abi_extra)) {
+            (other->abi_extra == framework->abi_extra ||
+             strcmp(other->abi_extra, framework->abi_extra) == 0)) {
             framework->abi_extra = other->abi_extra;
             break;
         }

--- a/pymetabind.h
+++ b/pymetabind.h
@@ -53,7 +53,7 @@
 
 /*
  * There are two ways to use this header file. The default is header-only style,
- * where all functions are defined as `inline`. If you want to emit functions
+ * where all functions are defined as `inline` (C++) / `static inline` (C). If you want to emit functions
  * as non-inline, perhaps so you can link against them from non-C/C++ code,
  * then do the following:
  * - In every compilation unit that includes this header, `#define PYMB_FUNC`
@@ -65,7 +65,11 @@
  *   compilation unit that doesn't request `PYMB_DECLS_ONLY`.
  */
 #if !defined(PYMB_FUNC)
-#define PYMB_FUNC inline
+#  ifdef __cplusplus
+#    define PYMB_FUNC inline
+#  else
+#    define PYMB_FUNC static inline
+#  endif
 #endif
 
 #if defined(__cplusplus)

--- a/pymetabind.h
+++ b/pymetabind.h
@@ -631,6 +631,9 @@ PYMB_FUNC void pymb_add_framework(struct pymb_registry* registry,
            "Free-threaded removal of bindings requires PyUnstable_TryIncRef(), "
            "which was added in CPython 3.14");
 #endif
+    // Defensive: ensure hook is clean before first list insertion to avoid UB
+    framework->hook.next = NULL;
+    framework->hook.prev = NULL;
     pymb_lock_registry(registry);
     PYMB_LIST_FOREACH(struct pymb_framework*, other, registry->frameworks) {
         // Intern `abi_extra` strings so they can be compared by pointer
@@ -663,6 +666,9 @@ PYMB_FUNC void pymb_add_binding(struct pymb_registry* registry,
 #if defined(Py_GIL_DISABLED) && PY_VERSION_HEX >= 0x030e0000
     PyUnstable_EnableTryIncRef((PyObject *) binding->pytype);
 #endif
+    // Defensive: ensure hook is clean before first list insertion to avoid UB
+    binding->hook.next = NULL;
+    binding->hook.prev = NULL;
     PyObject* capsule = PyCapsule_New(binding, "pymetabind_binding", NULL);
     int rv = -1;
     if (capsule) {


### PR DESCRIPTION
This PR fixes a bug I noticed while reviewing the code the first time, but never had time to confirm back then: the registry capsule was created without a destructor, so the `pymb_registry allocation` leaked at interpreter shutdown. I also added a couple of small defensive tweaks and other improvements I spotted in that first pass (using static inline in C to avoid linkage surprises, zeroing list hooks before first use, and a pointer-equality fast path when interning abi_extra). The only real issue is the leak — please feel free to just take whatever bits you find useful (read the commits for explanations).



I confirmed the leak fix with valgrind using a small extension:

## Before
```
PYTHONMALLOC=malloc valgrind --leak-check=full --show-leak-kinds=definite     python3 repro.py
==5100== Memcheck, a memory error detector
==5100== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==5100== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==5100== Command: python3 repro.py
==5100==
registry ptr: 0x4f92610
dropped capsule; exiting process (check valgrind for leak)
==5100==
==5100== HEAP SUMMARY:
==5100==     in use at exit: 41,468 bytes in 5 blocks
==5100==   total heap usage: 20,792 allocs, 20,787 frees, 2,790,954 bytes allocated
==5100==
==5100== 40,000 bytes in 1 blocks are definitely lost in loss record 5 of 5
==5100==    at 0x4889F94: calloc (vg_replace_malloc.c:1328)
==5100==    by 0x5000D97: pymb_get_registry (pymetabind.h:559)
==5100==    by 0x5000D97: touch (leaky.c:12)
==5100==    by 0x49C7FB: ??? (in /usr/bin/python3.11)
==5100==    by 0x4BB053: PyObject_Vectorcall (in /usr/bin/python3.11)
==5100==    by 0x4AA3EF: _PyEval_EvalFrameDefault (in /usr/bin/python3.11)
==5100==    by 0x4A0C7F: PyEval_EvalCode (in /usr/bin/python3.11)
==5100==    by 0x5F9757: ??? (in /usr/bin/python3.11)
==5100==    by 0x5F644F: ??? (in /usr/bin/python3.11)
==5100==    by 0x606E6F: ??? (in /usr/bin/python3.11)
==5100==    by 0x606A17: _PyRun_SimpleFileObject (in /usr/bin/python3.11)
==5100==    by 0x60677F: _PyRun_AnyFileObject (in /usr/bin/python3.11)
==5100==    by 0x604A0B: Py_RunMain (in /usr/bin/python3.11)
==5100==
==5100== LEAK SUMMARY:
==5100==    definitely lost: 40,000 bytes in 1 blocks
==5100==    indirectly lost: 0 bytes in 0 blocks
==5100==      possibly lost: 0 bytes in 0 blocks
==5100==    still reachable: 1,468 bytes in 4 blocks
==5100==         suppressed: 0 bytes in 0 blocks
==5100== Reachable blocks (those to which a pointer was found) are not shown.
==5100== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==5100==
==5100== For lists of detected and suppressed errors, rerun with: -s
==5100== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

## After
```
oot@8ab8d8f42755:/src# PYTHONMALLOC=malloc valgrind --leak-check=full --show-leak-kinds=definite     python3 repro.py
==5118== Memcheck, a memory error detector
==5118== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==5118== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==5118== Command: python3 repro.py
==5118==
registry ptr: 0x4f92690
dropped capsule; exiting process (check valgrind for leak)
==5118==
==5118== HEAP SUMMARY:
==5118==     in use at exit: 1,468 bytes in 4 blocks
==5118==   total heap usage: 20,793 allocs, 20,789 frees, 2,751,048 bytes allocated
==5118==
==5118== LEAK SUMMARY:
==5118==    definitely lost: 0 bytes in 0 blocks
==5118==    indirectly lost: 0 bytes in 0 blocks
==5118==      possibly lost: 0 bytes in 0 blocks
==5118==    still reachable: 1,468 bytes in 4 blocks
==5118==         suppressed: 0 bytes in 0 blocks
==5118== Reachable blocks (those to which a pointer was found) are not shown.
==5118== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==5118==
==5118== For lists of detected and suppressed errors, rerun with: -s
==5118== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```