### PR TITLE
Make pymb_get_registry() thread safe

### DIFF
--- a/pymetabind.h
+++ b/pymetabind.h
@@ -596,41 +596,111 @@ PYMB_FUNC struct pymb_registry* pymb_get_registry() {
 #else
     PyObject* dict = PyInterpreterState_GetDict(PyInterpreterState_Get());
 #endif
-    PyObject* key = PyUnicode_FromString("__pymetabind_registry__");
-    if (!dict || !key) {
-        Py_XDECREF(key);
+    
+    if (!dict) {
         return NULL;
     }
-    PyObject* capsule = PyDict_GetItem(dict, key);
-    if (capsule) {
+    
+    PyObject* key = PyUnicode_FromString("__pymetabind_registry__");
+    if (!key) {
+        return NULL;
+    }
+    
+#if PY_VERSION_HEX >= 0x030D0000
+    // 3.13+/free-threaded: use strong-ref APIs
+    PyObject* existing_capsule = PyDict_GetItemRef(dict, key);
+    if (existing_capsule) {
+        Py_DECREF(key);
+        pymb_registry* registry = (struct pymb_registry*) PyCapsule_GetPointer(
+                existing_capsule, "pymetabind_registry");
+        Py_DECREF(existing_capsule);
+        // WARNING: The returned pointer is only valid while the interpreter
+        // dict contains the registry capsule! Is technically possible that in
+        // free threaded builds another thread clears the capsule (by getting
+        // the interpreter dict and calling clear() on it or deleting/replacing
+        // the key) and we just removed our last reference to it so the registry
+        // pointer is now freed memory :(
+        return registry;
+    }
+#else
+    // Older CPython: borrowed ref is OK as long as GIL is held
+    PyObject* existing_capsule = PyDict_GetItem(dict, key);
+    if (existing_capsule) {
+        // WARNING: See above
         Py_DECREF(key);
         return (struct pymb_registry*) PyCapsule_GetPointer(
-                capsule, "pymetabind_registry");
+                existing_capsule, "pymetabind_registry");
     }
-    struct pymb_registry* registry;
-    registry = (struct pymb_registry*) calloc(1, sizeof(*registry));
-    if (registry) {
-        pymb_list_init(&registry->frameworks);
-        pymb_list_init(&registry->bindings);
-        // Attach a destructor so the registry memory is released at teardown
-        capsule = PyCapsule_New(registry, "pymetabind_registry",
-                                pymb_registry_capsule_destructor);
-        if (!capsule) {
-            free(registry);
-        } else {
-            // Store borrowed reference to the capsule to manage registry lifetime
-            // in pymb_add_framework and pymb_remove_framework
-            registry->capsule = capsule;
-            if (PyDict_SetItem(dict, key, capsule) == -1) {
-                registry = NULL; // will be deallocated by capsule destructor
-            }
-        }
-        Py_XDECREF(capsule);
-    } else {
+#endif
+
+    // Create new registry
+    struct pymb_registry* registry = (struct pymb_registry*) calloc(1, sizeof(*registry));
+    if (!registry) {
+        Py_DECREF(key);
         PyErr_NoMemory();
+        return NULL;
     }
+    
+    pymb_list_init(&registry->frameworks);
+    pymb_list_init(&registry->bindings);
+    
+    // Create capsule for our new registry
+    PyObject* new_capsule = PyCapsule_New(registry, "pymetabind_registry",
+                                          pymb_registry_capsule_destructor);
+    if (!new_capsule) {
+        free(registry);
+        Py_DECREF(key);
+        return NULL;
+    }
+    
+#if PY_VERSION_HEX >= 0x030D0000  // Python 3.13+ and free threaded Python
+    PyObject* result_capsule = NULL;
+    int status = PyDict_SetDefaultRef(dict, key, new_capsule, &result_capsule);
     Py_DECREF(key);
-    return registry;
+    
+    if (status == -1) {
+        // Error occurred
+        Py_DECREF(new_capsule);
+        return NULL;
+    } else if (status == 1) {
+        // Key was already present, someone else won the race
+        Py_DECREF(new_capsule);
+        
+        // Extract registry from the existing capsule (result_capsule is a strong ref)
+        struct pymb_registry* existing_registry = 
+            (struct pymb_registry*) PyCapsule_GetPointer(result_capsule, "pymetabind_registry");
+        Py_DECREF(result_capsule);
+        return existing_registry;
+    } else {
+        // status == 0: We successfully inserted our capsule
+        registry->capsule = new_capsule;
+        Py_DECREF(new_capsule);
+        Py_DECREF(result_capsule);
+        return registry;
+    }
+#else
+    // For older Python versions, use PyDict_SetDefault
+    PyObject* result_capsule = PyDict_SetDefault(dict, key, new_capsule);
+    Py_DECREF(key);
+    
+    if (!result_capsule) {
+        // Error occurred during setdefault
+        Py_DECREF(new_capsule);
+        return NULL;
+    }
+    
+    if (result_capsule == new_capsule) {
+        // We won the race - our capsule was inserted
+        registry->capsule = new_capsule;
+        return registry;
+    } 
+
+    // Someone else won the race - use their registry
+    Py_DECREF(new_capsule);
+    
+    return (struct pymb_registry*) PyCapsule_GetPointer(
+            result_capsule, "pymetabind_registry");
+#endif
 }
 
 /*

--- a/pymetabind.h
+++ b/pymetabind.h
@@ -792,6 +792,40 @@ PYMB_FUNC struct pymb_registry* pymb_get_registry() {
         Py_XDECREF(key);
         return NULL;
     }
+
+#if !defined(PYPY_VERSION) && PY_VERSION_HEX >= 0x030d0000
+    struct pymb_registry* registry =
+            (struct pymb_registry*) calloc(1, sizeof(*registry));
+    if (!registry) {
+        Py_DECREF(key);
+        PyErr_NoMemory();
+        return NULL;
+    }
+    pymb_list_init(&registry->frameworks);
+    pymb_list_init(&registry->bindings);
+    registry->deallocate_when_empty = 0;
+
+    PyObject* capsule = PyCapsule_New(registry, "pymetabind_registry",
+                                      pymb_registry_capsule_destructor);
+    if (!capsule) {
+        free(registry);
+        Py_DECREF(key);
+        return NULL;
+    }
+
+    PyObject* result_capsule = NULL;
+    int status = PyDict_SetDefaultRef(dict, key, capsule, &result_capsule);
+    Py_DECREF(key);
+    Py_DECREF(capsule);
+    if (status < 0) {
+        return NULL;
+    }
+
+    registry = (struct pymb_registry*) PyCapsule_GetPointer(
+            result_capsule, "pymetabind_registry");
+    Py_DECREF(result_capsule);
+    return registry;
+#else
     PyObject* capsule = PyDict_GetItem(dict, key);
     if (capsule) {
         Py_DECREF(key);
@@ -835,6 +869,7 @@ PYMB_FUNC struct pymb_registry* pymb_get_registry() {
     }
     Py_DECREF(key);
     return registry;
+#endif
 }
 
 /*


### PR DESCRIPTION
I was preparing some discussion about this for next week and so #3 so this is a draft to address it (this issue may motivate the fact that keeping this out of CPython may be a bit more complex as users can mess with the interpreter dictionary).

It turned out to be more tricky and messy than I expected. The new version uses the 3.13+ _Ref APIs for ensuring that free-threaded builds are safe, and falls back to the older `PyDict_SetDefault` path otherwise. One caveat is that there are some inherit races: if someone removes the capsule from the interpreter dict manually, we can still end up with dangling state (this isn’t new, but it’s worth noting).

Marking this as a draft for now since I’ll need to do another pass with a self-review to ensure I am not missing anything subtle. Feel free to close it if you have a better approach in mind or if you don't have the bandwidth to review ATM.

Tell me if you would like to go ahead and we can discuss the approach :)